### PR TITLE
Allow codex scripts to use custom repo path

### DIFF
--- a/Other_Stuff/README.md
+++ b/Other_Stuff/README.md
@@ -61,3 +61,12 @@ To push changes from within this environment:
 
 ```bash
 codexpush
+```
+
+`codexpush` uses `codex_push.sh` on the current directory. Override the repo path with `CODEX_REPO_DIR` or pass it as an argument:
+
+```bash
+CODEX_REPO_DIR=/path/to/repo codexpush
+# or
+codexpush /path/to/repo
+```

--- a/codex_push.sh
+++ b/codex_push.sh
@@ -2,7 +2,7 @@
 
 # 🌀 BEANS FRAMEWORK PUSH + MASTER LOGGING SCRIPT
 
-REPO_DIR="$HOME/Documents/GitHub/beans-framework"
+REPO_DIR="${CODEX_REPO_DIR:-${1:-$(pwd)}}"
 cd "$REPO_DIR" || {
   echo "❌ Could not find repo at $REPO_DIR"
   exit 1

--- a/setup_codex_env.sh
+++ b/setup_codex_env.sh
@@ -5,7 +5,7 @@
 echo "🌱 Starting Beans Framework setup..."
 
 # 🔧 Define repo path
-REPO_DIR="$HOME/Documents/GitHub/beans-framework"
+REPO_DIR="${CODEX_REPO_DIR:-${1:-$(pwd)}}"
 
 # 📁 Make folder if it doesn't exist
 mkdir -p "$REPO_DIR"
@@ -22,7 +22,7 @@ mkdir -p Core-Beans push-logs
 
 # 🧠 Create codexpush alias if not already in .zshrc
 if ! grep -q "codexpush" ~/.zshrc; then
-  echo 'alias codexpush="~/Documents/GitHub/beans-framework/codex_push.sh"' >> ~/.zshrc
+  echo "alias codexpush=\"${REPO_DIR}/codex_push.sh ${REPO_DIR}\"" >> ~/.zshrc
   echo "🔁 Alias 'codexpush' added to .zshrc"
   source ~/.zshrc
 else
@@ -33,8 +33,11 @@ fi
 cat > codex_push.sh <<'EOF'
 #!/bin/bash
 
-REPO_DIR="$HOME/Documents/GitHub/beans-framework"
-cd "$REPO_DIR" || exit
+REPO_DIR="${CODEX_REPO_DIR:-${1:-$(pwd)}}"
+cd "$REPO_DIR" || {
+  echo "❌ Could not find repo at $REPO_DIR"
+  exit 1
+}
 
 echo "📂 Checking for changes..."
 CHANGES=$(git status --porcelain)


### PR DESCRIPTION
## Summary
- make `codex_push.sh` accept CODEX_REPO_DIR or an argument to pick the repo directory
- apply the same logic in `setup_codex_env.sh` and update its alias
- refresh the codex instructions in `Other_Stuff/README.md`

## Testing
- `bash -n codex_push.sh`
- `bash -n setup_codex_env.sh`


------
https://chatgpt.com/codex/tasks/task_e_68419f680df08320bcbf1e179ab1bc4d