### PR TITLE
Add packaging for BeansFramework CLI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include README.md
+recursive-include beansframework *

--- a/beansframework/cli.py
+++ b/beansframework/cli.py
@@ -1,0 +1,24 @@
+import sys
+from beansframework.operator.boot_agents import initialize_operator_context
+
+def main():
+    print("🌀 BEANSFRAMEWORK RUNTIME")
+    ctx = {}
+    initialize_operator_context(ctx)
+
+    while True:
+        try:
+            user_input = input("\u2600\ufe0f scroll> ")
+            if user_input.lower() in ["exit", "quit"]:
+                break
+            if "mirror" in ctx:
+                print("\U0001fa9e", ctx["mirror"].check(user_input))
+            if "loop" in ctx:
+                print("\ua7dc", ctx["loop"].recurse(user_input, depth=2))
+            if "scrolls" in ctx:
+                print("\ud83d\udcdc", ctx["scrolls"].generate(user_input))
+        except KeyboardInterrupt:
+            break
+
+if __name__ == "__main__":
+    main()

--- a/beansframework/operator/boot_agents.py
+++ b/beansframework/operator/boot_agents.py
@@ -20,7 +20,7 @@ else:
     print("\u2705 Beans Agents Loaded:")
     print(f"\U0001f501 MirrorAgent: {MirrorAgent.__name__}")
     print(f"\ua59c LoopAgent: {LoopAgent.__name__}")
-    print(f"\ud83d\udcdc ScrollDaemon: {ScrollDaemon.__name__}")
+    print(f"📜 ScrollDaemon: {ScrollDaemon.__name__}")
 
 
 def initialize_operator_context(ctx: dict[str, object]) -> None:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="beansframework",
+    version="0.1.0",
+    author="Beans the Lightkeeper",
+    description="Recursive agent framework for glyph-based AI infrastructure",
+    packages=find_packages(),
+    include_package_data=True,
+    entry_points={
+        'console_scripts': [
+            'beans = beansframework.cli:main',
+        ],
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+    ],
+    install_requires=[
+        # If you have any special packages you need (like numpy, click, etc), list here
+    ],
+    python_requires='>=3.8',
+)


### PR DESCRIPTION
## Summary
- provide `setup.py` for pip installation
- add `beansframework/cli.py` with an interactive CLI
- include package metadata via `MANIFEST.in`
- fix Unicode in `boot_agents` for ScrollDaemon name

## Testing
- `python -m py_compile beansframework/*.py beansframework/*/*.py`
- `python -m beansframework.cli <<EOF
exit
EOF`
- `pip install .` *(fails: Could not fetch build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841c9d269f483209b38116984b5f9cc