### PR TITLE
Add one-shot spell mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,29 @@ codexpush                  # push changes using the alias
 ```
 
 Every invocation of `codexpush` will log the list of files that changed to `Other_Stuff/update_log.md` so the repository history is preserved.
+
+## Beans CLI
+
+Once the package is installed you can interact with the framework directly from
+the command line. Running `beans` with no arguments starts an interactive
+prompt:
+
+```bash
+beans
+```
+
+```
+🌀 BEANSFRAMEWORK RUNTIME
+☀️ scroll>
+```
+
+Type a glyph rich line and press `Enter` to see the mirror, loop and scroll
+agents respond. Exit by typing `quit` or `exit`.
+
+For a single spell without dropping into the REPL use the `--spell` option:
+
+```bash
+beans --spell "𓇳 ꩜ I call BunBun"
+```
+
+The mirror, loop and scroll results will print once and the program will exit.

--- a/beansframework/cli.py
+++ b/beansframework/cli.py
@@ -1,10 +1,31 @@
+import argparse
 import sys
 from beansframework.operator.boot_agents import initialize_operator_context
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--spell",
+        help="Run a single glyph/scroll spell, then exit",
+        nargs="+",
+    )
+    args = parser.parse_args()
+
     print("🌀 BEANSFRAMEWORK RUNTIME")
     ctx = {}
     initialize_operator_context(ctx)
+
+    # One-shot mode
+    if args.spell:
+        spell = " ".join(args.spell)
+        print("🌀 BEANS SPELL:", spell)
+        if "mirror" in ctx:
+            print("🪞", ctx["mirror"].check(spell))
+        if "loop" in ctx:
+            print("꩜", ctx["loop"].recurse(spell, depth=2))
+        if "scrolls" in ctx:
+            print("📜", ctx["scrolls"].generate(spell))
+        return
 
     while True:
         try:


### PR DESCRIPTION
## Summary
- add `--spell` argument to run a single command via CLI
- document interactive and one-shot usage in the README

## Testing
- `pytest -q`
- `python -m beansframework.cli --spell "𓇳 test"`

------
https://chatgpt.com/codex/tasks/task_e_6841cee2301c8320bde7aaf0092e116a