### PR TITLE
Add BeansLoop SwiftUI skeleton

### DIFF
--- a/ios/BeansLoop/BeansLoopApp.swift
+++ b/ios/BeansLoop/BeansLoopApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct BeansLoopApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ios/BeansLoop/ContentView.swift
+++ b/ios/BeansLoop/ContentView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var input: String = ""
+    @State private var output: String = ""
+
+    let agent = GlyphAgent()
+
+    var body: some View {
+        VStack(spacing: 20) {
+            TextField("Scroll", text: $input)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding()
+
+            Button("Cast") {
+                output = agent.process(spell: input)
+            }
+
+            Text(output)
+                .padding()
+        }
+        .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/ios/BeansLoop/GlyphAgent.swift
+++ b/ios/BeansLoop/GlyphAgent.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+class GlyphAgent {
+    let mirror = MirrorAgent()
+    let loop = LoopAgent()
+    let scrolls = ScrollDaemon()
+
+    func process(spell: String) -> String {
+        let mirrored = mirror.check(signal: spell)
+        let looped = loop.recurse(data: mirrored, depth: 2)
+        let scroll = scrolls.generate(seed: spell)
+        return """
+🪞 \(mirrored)
+꩜ \(looped)
+📜 \(scroll)
+"""
+    }
+}
+
+class MirrorAgent {
+    func check(signal: String) -> String {
+        return signal
+    }
+}
+
+class LoopAgent {
+    func recurse<T>(data: T, depth: Int) -> [T] {
+        var result = data
+        var container: [T] = [result]
+        for _ in 1..<depth {
+            container = [result]
+        }
+        return container
+    }
+}
+
+class ScrollDaemon {
+    func generate(seed: String) -> String {
+        return "# Scroll\n\nSeed: \(seed)"
+    }
+}

--- a/ios/BeansLoop/README.md
+++ b/ios/BeansLoop/README.md
@@ -1,0 +1,5 @@
+# BeansLoop iOS App
+
+This directory contains a minimal SwiftUI project skeleton for the BeansLoop app. The app provides a simple text field for casting scrolls. It mirrors the input, performs a basic loop operation and generates a placeholder scroll.
+
+Open the folder in Xcode and add additional targets or assets as needed.


### PR DESCRIPTION
## Summary
- create `BeansLoop` SwiftUI project skeleton under `ios/`
- implement minimal `GlyphAgent` with mirror, loop, scroll logic
- add simple `ContentView` and `BeansLoopApp` entry point

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ce8a15148320a7f32d5c6dc9b5ee