### PR TITLE
Remove unused sys import

### DIFF
--- a/beansframework/cli.py
+++ b/beansframework/cli.py
@@ -1,4 +1,3 @@
-import sys
 from beansframework.operator.boot_agents import initialize_operator_context
 
 def main():


### PR DESCRIPTION
## Summary
- remove unused `sys` import from `beansframework/cli.py`

## Testing
- `python -m beansframework.cli --spell "𓇳 test"`

------
https://chatgpt.com/codex/tasks/task_e_6841d08d0cc88320a2f213a704630d5e