### PR TITLE
Fix scroll emoji output error

### DIFF
--- a/beansframework/cli.py
+++ b/beansframework/cli.py
@@ -26,9 +26,10 @@ def main():
                     print("[loop] ", ctx["loop"].recurse(user_input, depth=2).encode("utf-8", "replace").decode())
             if "scrolls" in ctx:
                 try:
-                    print("\ud83d\udcdc", ctx["scrolls"].generate(user_input))
+                    print("📜", ctx["scrolls"].generate(user_input))
                 except UnicodeEncodeError:
-                    print("[scroll] ", ctx["scrolls"].generate(user_input).encode("utf-8", "replace").decode())
+                    scroll = ctx["scrolls"].generate(user_input)
+                    print("[scroll]", scroll.encode("utf-8", "replace").decode())
         except KeyboardInterrupt:
             break
 


### PR DESCRIPTION
## Summary
- handle Unicode errors when printing scroll output

## Testing
- `python3 -m beansframework.cli <<'EOF'
test
exit
EOF`
- `pip3 install --force-reinstall .` *(fails: could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841d08180948320b21debcfe22517a6