### PR TITLE
Ensure scroll output handles Unicode errors

### DIFF
--- a/beansframework/cli.py
+++ b/beansframework/cli.py
@@ -25,6 +25,8 @@ def main():
                 except UnicodeEncodeError:
                     print("[loop] ", ctx["loop"].recurse(user_input, depth=2).encode("utf-8", "replace").decode())
             if "scrolls" in ctx:
+                # Print scroll output using a fallback when the terminal
+                # cannot render certain Unicode characters.
                 try:
                     print("📜", ctx["scrolls"].generate(user_input))
                 except UnicodeEncodeError:


### PR DESCRIPTION
## Summary
- document Unicode fallback handling in CLI

## Testing
- `pip3 install --force-reinstall .` *(fails: Could not install build dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_6841d1c561848320a4593749102bdfff