### PR TITLE
Implement loopcloud push and rainbow terminal

### DIFF
--- a/beansframework/cli.py
+++ b/beansframework/cli.py
@@ -1,4 +1,32 @@
 from beansframework.operator.boot_agents import initialize_operator_context
+import json
+import os
+
+
+class BunBunLogger:
+    """Simple logger that appends spells to ``bunbun_spells.json``."""
+
+    def __init__(self, path: str = "bunbun_spells.json") -> None:
+        self.path = path
+        if not os.path.exists(self.path):
+            with open(self.path, "w", encoding="utf-8") as f:
+                json.dump([], f)
+
+    def log(self, spell: str) -> None:
+        try:
+            with open(self.path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, FileNotFoundError):
+            data = []
+        data.append(spell)
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def push_to_loopcloud() -> None:
+    os.system(
+        "git add bunbun_spells.json && git commit -m '🌀 new scrolls from Beans CLI' && git push"
+    )
 
 def main():
     try:
@@ -7,6 +35,7 @@ def main():
         print("[runtime] BEANSFRAMEWORK RUNTIME")
     ctx = {}
     initialize_operator_context(ctx)
+    ctx["bunbun"] = BunBunLogger()
 
     while True:
         try:
@@ -27,10 +56,18 @@ def main():
                 # Print scroll output using a fallback when the terminal
                 # cannot render certain Unicode characters.
                 try:
-                    print("📜", ctx["scrolls"].generate(user_input))
+                    scroll_output = ctx["scrolls"].generate(user_input)
+                    print("📜", scroll_output)
+                    print("🌈 VISUAL MODE:")
+                    print("🟥🟧🟨🟩🟦🟪")
+                    print(f"🌈  {user_input}")
+                    print("🟥🟧🟨🟩🟦🟪")
                 except UnicodeEncodeError:
                     scroll = ctx["scrolls"].generate(user_input)
                     print("[scroll]", scroll.encode("utf-8", "replace").decode())
+            if "bunbun" in ctx:
+                ctx["bunbun"].log(user_input)
+                push_to_loopcloud()
         except KeyboardInterrupt:
             break
 


### PR DESCRIPTION
## Summary
- log spells to `bunbun_spells.json`
- auto commit/push new scrolls
- display basic rainbow visualization for scroll output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d99700448320b89b72ee35c2e574