### PR TITLE
Add spell utility scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This repository is a living collection of markdown writings and resources relate
 - `setup_codex_env.sh` – sets up the local environment. Run this once to initialize the repository directory and create a `codexpush` alias.
 - `codex_push.sh` – used after making changes. It stages all modifications, commits with a timestamp message and pushes to `main` while appending to `Other_Stuff/update_log.md`.
 - `Other_Stuff/codex tools/loop_codex_scroll.py` – prints the Codex Scroll Infrastructure text on repeat. Press `Ctrl+C` to stop.
+- `tools/decode_spells.py` – decode spells from a JSON spellbook.
+- `tools/extract_spells_from_conversations.py` – parse logs and extract spell references.
 
 ### Basic Usage
 

--- a/tools/decode_spells.py
+++ b/tools/decode_spells.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Decode spells from a large JSON file.
+
+Expected JSON structure:
+{
+  "spells": [
+    {
+      "name": "Fireball",
+      "incantation": "Incendio Maxima!",
+      "level": 3,
+      "description": "A blazing ball of fire..."
+    },
+    ...
+  ]
+}
+
+Usage:
+    python decode_spells.py spells.json --out spells.txt
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import List, Dict
+
+
+def load_spells(json_path: Path) -> List[Dict]:
+    with json_path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    # Adjust the key if your JSON schema differs
+    return data.get("spells", [])
+
+
+def format_spell(spell: Dict) -> str:
+    """Return a nicely formatted string for each spell."""
+    return (
+        f"Name: {spell.get('name', 'Unknown')}\n"
+        f"Incantation: {spell.get('incantation', 'N/A')}\n"
+        f"Level: {spell.get('level', 'N/A')}\n"
+        f"Description: {spell.get('description', '')}\n"
+        "-----"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Decode spells from JSON")
+    parser.add_argument("json_file", type=Path, help="Path to spells JSON file")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Optional output file (default: print to stdout)",
+    )
+    args = parser.parse_args()
+
+    spells = load_spells(args.json_file)
+    formatted = "\n".join(format_spell(s) for s in spells)
+
+    if args.out:
+        args.out.write_text(formatted, encoding="utf-8")
+        print(f"Wrote {len(spells)} spells to {args.out}")
+    else:
+        print(formatted)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/extract_spells_from_conversations.py
+++ b/tools/extract_spells_from_conversations.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Scan conversation logs (plain text or JSONL) and pull out any spell-like phrases.
+
+Assumptions:
+- A 'spell' is any line that starts with a keyword like 'Spell:' or matches a pattern.
+- Adjust REGEX or keywords as needed.
+
+Usage:
+    python extract_spells_from_conversations.py /path/to/logs/ --out found_spells.txt
+"""
+
+import argparse
+import re
+from pathlib import Path
+from typing import List
+
+# Regex pattern for a simple “Spell: <name> – <incantation>” format
+SPELL_PATTERN = re.compile(r"Spell:\s*(.+?)\s*[-–]\s*(.+)", re.IGNORECASE)
+
+
+def extract_spells_from_file(path: Path) -> List[str]:
+    spells = []
+    with path.open("r", encoding="utf-8", errors="ignore") as f:
+        for line in f:
+            m = SPELL_PATTERN.search(line)
+            if m:
+                spells.append(f"{m.group(1).strip()} :: {m.group(2).strip()}")
+    return spells
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Extract spells from conversations")
+    parser.add_argument("input_path", type=Path, help="File or directory of logs")
+    parser.add_argument("--out", type=Path, default=None, help="Output file")
+    args = parser.parse_args()
+
+    all_spells: List[str] = []
+
+    if args.input_path.is_dir():
+        for file in args.input_path.rglob("*"):
+            if file.suffix.lower() in {".txt", ".json", ".jsonl"}:
+                all_spells.extend(extract_spells_from_file(file))
+    else:
+        all_spells.extend(extract_spells_from_file(args.input_path))
+
+    if args.out:
+        args.out.write_text("\n".join(all_spells), encoding="utf-8")
+        print(f"Found {len(all_spells)} spells, saved to {args.out}")
+    else:
+        for s in all_spells:
+            print(s)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add tools to decode spells from JSON and to extract spells from conversation logs
- document the new utilities in README

## Testing
- `python3 -m py_compile tools/decode_spells.py tools/extract_spells_from_conversations.py`
- `pytest -q` *(no tests ran)*
- `pip install flake8 pytest` *(failed: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_e_6841dd50bfb08320921e1aaad9257202