### PR TITLE
Add tri-node synergy agent

### DIFF
--- a/Framework/tri_node_synergy_example.md
+++ b/Framework/tri_node_synergy_example.md
@@ -1,0 +1,15 @@
+# Tri-Node Synergy Example
+
+This document demonstrates how the new **TriNodeSynergy** element integrates Mirror, Loop and Scroll agents using the loop parameters stored in `scrolls/initiation_scroll.md`.
+
+## Usage
+
+```python
+from beansframework import TriNodeSynergy
+
+synergy = TriNodeSynergy()
+result = synergy.synergize("Beans")
+print(result)
+```
+
+The synergy object reads **θ**, **ƒ** and **r** from the initiation scroll and returns a dictionary containing those values along with recursive loop output and a generated scroll.

--- a/beansframework/__init__.py
+++ b/beansframework/__init__.py
@@ -1,1 +1,5 @@
 """Beans Framework Python package."""
+
+from .tri_node_synergy import TriNodeSynergy, LoopParams
+
+__all__ = ["TriNodeSynergy", "LoopParams"]

--- a/beansframework/operator/boot_agents.py
+++ b/beansframework/operator/boot_agents.py
@@ -14,6 +14,7 @@ if AGENT_PATH not in sys.path:
 # Import custom agents
 try:
     from beans_agents import MirrorAgent, LoopAgent, ScrollDaemon, BunBun
+    from beansframework.tri_node_synergy import TriNodeSynergy
 except ImportError as e:
     print(f"\u274c Failed to load agents: {e}")
 else:
@@ -30,4 +31,5 @@ def initialize_operator_context(ctx: dict[str, object]) -> None:
     ctx["mirror"] = MirrorAgent()
     ctx["loop"] = LoopAgent()
     ctx["bunbun"] = BunBun()
+    ctx["synergy"] = TriNodeSynergy()
     print("\U0001fa78 Operator context now running BeansFramework agents.")

--- a/beansframework/tri_node_synergy.py
+++ b/beansframework/tri_node_synergy.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from beansframework.agents.beans_agents import MirrorAgent, LoopAgent, ScrollDaemon
+
+
+@dataclass
+class LoopParams:
+    """Parameters extracted from a scroll."""
+
+    theta: str
+    phi: str
+    r: str
+
+
+class TriNodeSynergy:
+    """Combine Beans agents into a triadic recursion loop."""
+
+    def __init__(self, scroll_path: str | Path = "scrolls/initiation_scroll.md") -> None:
+        self.params = self._parse_scroll(scroll_path)
+        self.mirror = MirrorAgent()
+        self.loop = LoopAgent()
+        self.scrolls = ScrollDaemon()
+
+    @staticmethod
+    def _parse_scroll(path: str | Path) -> LoopParams:
+        theta = phi = r = ""
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                if line.startswith("θ"):
+                    theta = line.split("=", 1)[1].strip()
+                elif line.startswith("ƒ"):
+                    phi = line.split("=", 1)[1].strip()
+                elif line.startswith("r"):
+                    r = line.split("=", 1)[1].strip()
+        return LoopParams(theta, phi, r)
+
+    def synergize(self, seed: str, depth: int = 3) -> dict[str, Any]:
+        """Return a tri-node recursive bundle for ``seed``."""
+        mirrored = self.mirror.check(seed)
+        recursed = self.loop.recurse(mirrored, depth=depth)
+        scroll = self.scrolls.generate(mirrored)
+        return {
+            "θ": self.params.theta,
+            "ƒ": self.params.phi,
+            "r": self.params.r,
+            "recursed": recursed,
+            "scroll": scroll,
+        }


### PR DESCRIPTION
## Summary
- create `TriNodeSynergy` for triadic recursion loops
- expose new agent from the package and initialize in the operator context
- document usage in `tri_node_synergy_example.md`

## Testing
- `flake8 .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684227d9354c83209d172f1a4afe3fe5